### PR TITLE
Onboard to the OSS Community Develocity Instance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,13 +27,11 @@ jobs:
             21
             25
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+      - name: Set up OSS Community Develocity Instance for Gradle
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          build-scan-publish: true
-          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
-          build-scan-terms-of-use-agree: 'yes'
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Build library
         run: |
@@ -63,13 +61,11 @@ jobs:
             21
             25
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+      - name: Set up OSS Community Develocity Instance for Gradle
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          build-scan-publish: true
-          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
-          build-scan-terms-of-use-agree: 'yes'
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Publish to Maven staging
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,13 +38,11 @@ jobs:
             21
             25
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+      - name: Set up OSS Community Develocity Instance for Gradle
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          build-scan-publish: true
-          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
-          build-scan-terms-of-use-agree: 'yes'
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 
       - name: Get version

--- a/.github/workflows/tree-sitter.yaml
+++ b/.github/workflows/tree-sitter.yaml
@@ -45,15 +45,13 @@ jobs:
           distribution: 'temurin'
           java-version: 25
 
-      - name: Setup Gradle
+      - name: Set up OSS Community Develocity Instance for Gradle
         if: github.event_name != 'schedule' || steps.check_commits.outputs.run_tests == 'true'
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           # Use setup-gradle caching
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          build-scan-publish: true
-          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
-          build-scan-terms-of-use-agree: 'yes'
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Run Tree-Sitter Tests
         if: github.event_name != 'schedule' || steps.check_commits.outputs.run_tests == 'true'

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 # Gradle MCP server
 
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://community.develocity.cloud/scans?search.rootProjectNames=gradle-mcp)
+
 A Model Context Protocol (MCP) server for Gradle. It gives AI agents the tools they need to explore project structures, run tasks, audit dependencies, and interact with the JVM runtime.
 
 ##### Features

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,36 @@
 plugins {
+    id("com.gradle.develocity") version "4.4.1"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.6.0"
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
+
+val isCI = System.getenv("CI") != null
+
+develocity {
+    server = "https://community.develocity.cloud"
+    projectId = "rnett"
+    buildScan {
+        uploadInBackground = !isCI
+        publishing.onlyIf { it.isAuthenticated }
+        obfuscation {
+            ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } }
+        }
+    }
+}
+
+buildCache {
+    local {
+        isEnabled = true
+    }
+
+    remote(develocity.buildCache) {
+        isEnabled = true
+        // Check access key presence to avoid build cache errors on PR builds when access key is not present
+        val accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")
+        isPush = isCI && accessKey != null
+    }
+}
+
 rootProject.name = "gradle-mcp"
 include("repl-worker", "repl-shared")
 


### PR DESCRIPTION
# Onboard to the OSS Community Develocity Instance

This PR adds [Develocity](https://gradle.com/develocity) Build Scan® and Build Cache support
for this project, publishing to the **OSS Community Develocity Instance** at
<https://community.develocity.cloud> under project ID `rnett`.

## What this PR adds

- The Develocity Gradle extension/plugin and the Common Custom User Data Gradle
  extension/plugin, applied at the latest released versions.
- settings.gradle.kts pointing the build at `https://community.develocity.cloud` and
  associating builds with project `rnett`.
- A "Revved up by Develocity" badge in the README linking to the filtered Build Scan list
  for this project's root project name.
- A setup step in each GitHub Actions workflow that runs the build, so CI publishes Build
  Scans automatically using a short-lived access token.

## Step 1 — Get an access key for `community.develocity.cloud`

Build Scan publishing **and** Build Cache writes from CI need a Develocity access key.

1. Visit <https://community.develocity.cloud>.
2. **Sign in as the CI service account that the Develocity Solutions team has provisioned
   for your project** — that account was shared with you out-of-band when this onboarding
   was set up. The access key inherits that account's project memberships and permissions,
   which is exactly what you want for CI.
3. From the user menu in the top-right, open **My settings** → **Access keys**.
4. Click **Generate access key**, give it a description (e.g. `GitHub Actions`), and copy
   the generated key. Keep this tab open until you complete Step 2 — the key is only
   shown once.

## Step 2 — Set the GitHub Actions secret on this repository

CI uses a repository secret named `DEVELOCITY_ACCESS_KEY` to authenticate to
`community.develocity.cloud`.

1. Open this repository on GitHub.
2. Click **Settings**.
3. In the left sidebar, click **Secrets and variables** → **Actions**.
4. Click **New repository secret**. (If a `DEVELOCITY_ACCESS_KEY` secret already exists,
   click its **Update** button instead.)
5. Set **Name** to:

   ```
   DEVELOCITY_ACCESS_KEY
   ```

6. Set **Secret** to the value below, replacing `PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE`
   with the key you copied in Step 1:

   ```
   community.develocity.cloud=PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE
   ```

   The `community.develocity.cloud=` prefix is **required** — without the host name, the
   access key is silently ignored. This is the most common point of failure when
   onboarding, so please double-check the format.
7. Click **Add secret** (or **Update secret**).

## Step 3 — Provision an access key for your local builds

Developers building this project locally should provision an access key for
`community.develocity.cloud` so their Build Scans publish and they get reads
from the remote Build Cache. The Develocity Gradle plugin's
`provisionDevelocityAccessKey` task does this in a single command — it opens
the browser, asks the developer to confirm, and writes the key to
`~/.gradle/develocity/keys.properties` automatically.

**Before running this command**, sign out of `community.develocity.cloud` in
your browser (or use a private/incognito window) so the access key gets
associated with **your personal account**, not the CI service account you
signed in as for Step 1.

```
./gradlew provisionDevelocityAccessKey
```

## Note on the CI run on this PR

This PR was prepared from a fork. Forks can't read your repository's secrets, so the
workflow run on this PR cannot publish to `community.develocity.cloud` even after you set
the secret in Step 2.

If you want CI verification before merging, push the branch
`dv/onboard-oss-community-develocity-instance` to a temporary branch on **this** repo (not
the fork) and re-run the workflow there — it will pick up the secret and publish a Build
Scan.

After merging, every CI run **on this repository** will publish a Build Scan to
<https://community.develocity.cloud>. CI runs from forks of this repository will not (forks
don't have access to the secret either), and that's expected.
